### PR TITLE
Add Google Analytics script to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,14 @@
   <link rel="icon" href="https://smashpadelindonesia.com/favicon.ico" type="image/x-icon">
   <!-- Preload header image to improve LCP -->
   <link rel="preload" href="https://smashpadelindonesia.com/PXL_20250216_111147448-smaller.webp" as="image">
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-BX42KMMYGF"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-BX42KMMYGF');
+  </script>
 </head>
 <body>
   <header>


### PR DESCRIPTION
Add Google Analytics script to `index.html` file.

* Add the Google Analytics script with ID 'G-BX42KMMYGF' before the closing `</head>` tag.
* Include the async script source from `https://www.googletagmanager.com/gtag/js?id=G-BX42KMMYGF`.
* Add the script to initialize and configure Google Analytics.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/JulesBrookfield/smashpadel/pull/6?shareId=143d2240-33ca-412a-a029-580c78c4a525).